### PR TITLE
integration: support using different listen addr for tests

### DIFF
--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -82,6 +82,7 @@ func ApplyCRDs(kubeConfig *rest.Config) error {
 func NewEnvironment(kubeConfig *rest.Config) *Environment {
 	atomic.AddInt32(&namespaceCounter, 1)
 	namespaceID := gomegaConfig.GinkgoConfig.ParallelNode*100 + int(namespaceCounter)
+	log.Printf("DEBUG: setting up new environment\n")
 
 	return &Environment{
 		ID:        namespaceID,

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -94,7 +94,7 @@ func NewEnvironment(kubeConfig *rest.Config) *Environment {
 			Fs:                   afero.NewOsFs(),
 		},
 		Machine: Machine{
-			pollTimeout:  300 * time.Second,
+			pollTimeout:  30 * time.Second,
 			pollInterval: 500 * time.Millisecond,
 		},
 		KubeConfig: kubeConfig,

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"strings"
 	"time"
@@ -57,6 +58,7 @@ func (m *Machine) CreateNamespace(namespace string) (TearDownFunc, error) {
 			PropagationPolicy:  &b,
 		})
 		if err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("ERROR: Failed to delete namespace %s: %v\n", namespace, err)
 			return err
 		}
 		return nil

--- a/integration/environment/namespace.go
+++ b/integration/environment/namespace.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -26,6 +27,7 @@ func (e *Environment) SetupNamespace() error {
 	}
 
 	e.Teardown = func(wasFailure bool) {
+		log.Printf("DEBUG: Tearing down... failure? %v\n", wasFailure)
 		if wasFailure {
 			fmt.Println("Collecting debug information...")
 

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -63,11 +63,16 @@ func (e *Environment) setupCFOperator() error {
 
 	sshUser, shouldForwardPort := os.LookupEnv("ssh_server_user")
 	if shouldForwardPort {
+		var remoteAddr string
+		var ok bool
+		if remoteAddr, ok = os.LookupEnv("ssh_server_listen_address"); !ok {
+			remoteAddr = whh
+		}
 		go func() {
 			cmd := exec.Command(
 				"ssh", "-fNT", "-i", "/tmp/cf-operator-tunnel-identity", "-o",
 				"UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-R",
-				fmt.Sprintf("%s:%[2]d:localhost:%[2]d", whh, port),
+				fmt.Sprintf("%s:%[2]d:localhost:%[2]d", remoteAddr, port),
 				fmt.Sprintf("%s@%s", sshUser, whh))
 
 			stdOutput, err := cmd.CombinedOutput()

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -134,6 +134,7 @@ func (e *Environment) setupCFOperator() error {
 }
 
 func (e *Environment) startOperator() chan struct{} {
+	log.Printf("DEBUG: Starting operator\n")
 	stop := make(chan struct{})
 	go func() {
 		err := e.mgr.Start(stop)

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"k8s.io/client-go/rest"
@@ -32,10 +33,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}
 
 	// Ginkgo node 1 gets to setup the CRDs
+	log.Printf("DEBUG: Applying CRDs")
 	err = environment.ApplyCRDs(kubeConfig)
 	if err != nil {
 		fmt.Printf("WARNING: failed to apply CRDs: %v\n", err)
 	}
+	log.Printf("DEBUG: CRDs applied")
 
 	return []byte{}
 }, func([]byte) {

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -65,6 +65,7 @@ func NewManager(ctx context.Context, config *config.Config, cfg *rest.Config, op
 
 // ApplyCRDs applies a collection of CRDs into the cluster
 func ApplyCRDs(config *rest.Config) error {
+	log.Printf("DEBUG: Applying CRDs...\n")
 	exClient, err := extv1client.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "Could not get kube client")

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"log"
 
 	"github.com/pkg/errors"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -115,10 +116,12 @@ func ApplyCRDs(config *rest.Config) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to apply CRD '%s'", res.name)
 		}
+		log.Printf("DEBUG: Waiting for CRD '%s' to be ready...\n", res.name)
 		err = crd.WaitForCRDReady(exClient, res.name)
 		if err != nil {
 			return errors.Wrapf(err, "failed to wait for CRD '%s' ready", res.name)
 		}
+		log.Printf("DEBUG: CRD '%s' is ready\n", res.name)
 	}
 
 	return nil

--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os/exec"
 	"runtime/debug"
 	"strings"
@@ -393,11 +394,13 @@ func DeleteWebhooks(ns string) error {
 	var messages string
 	webHookName := fmt.Sprintf("%s-%s", "cf-operator-hook", ns)
 
+	log.Printf("Deleting mutating webhook %s\n", webHookName)
 	_, err := runBinary(kubeCtlCmd, "delete", "--ignore-not-found", "mutatingwebhookconfiguration", webHookName)
 	if err != nil {
 		messages = fmt.Sprintf("%v%v\n", messages, err.Error())
 	}
 
+	log.Printf("Deleting validating webhook %s\n", webHookName)
 	_, err = runBinary(kubeCtlCmd, "delete", "--ignore-not-found", "validatingwebhookconfiguration", webHookName)
 	if err != nil {
 		messages = fmt.Sprintf("%v%v\n", messages, err.Error())


### PR DESCRIPTION
In some configurations (notably OpenStack), the address that the SSH server listens on (for port forwarding) may be different from the public IP address required to reach the port-forwarded target.  Make it possible to configure the two separately.